### PR TITLE
Data extraction fix

### DIFF
--- a/input_pipeline/data_extraction.py
+++ b/input_pipeline/data_extraction.py
@@ -2,6 +2,7 @@ from os import path
 from typing import List, Dict
 import pickle as js
 
+POSITION = 0
 TOKEN = 2
 HEAD = 6
 RELATION = 7
@@ -37,21 +38,22 @@ class DataSetEntry(object):
 
     for line in lines:
       line_fields = line.split('\t')
-
-      # TODO: proces entries with missing head
-      # Make sure we are processing token lines having NO_FIELDS columns
       if len(line_fields) == NO_FIELDS:
-        token, head, relation = str(line_fields[TOKEN]),\
-                                int(line_fields[HEAD]),\
-                                str(line_fields[RELATION])
+        position_in_sentence = line_fields[POSITION]
+        # Skip words tokenized in multiple tokens (eg don't -> do not)
+        # that don't have a single int position associated and have missing data. 
+        if position_in_sentence.isnumeric():
+          token, head, relation = str(line_fields[TOKEN]),\
+                                  int(line_fields[HEAD]),\
+                                  str(line_fields[RELATION])
 
-        if token not in dataset.tokens_vocab.keys():
-          dataset.tokens_vocab.update({token: len(dataset.tokens_vocab.keys())})
-        if relation not in dataset.relations_vocab.keys():
-          dataset.relations_vocab.update({relation: len(dataset.relations_vocab.keys())})
-        self.tokens.append(dataset.tokens_vocab[token])
-        self.heads.append(head)
-        self.labels.append(dataset.relations_vocab[relation])
+          if token not in dataset.tokens_vocab.keys():
+            dataset.tokens_vocab.update({token: len(dataset.tokens_vocab.keys())})
+          if relation not in dataset.relations_vocab.keys():
+            dataset.relations_vocab.update({relation: len(dataset.relations_vocab.keys())})
+          self.tokens.append(dataset.tokens_vocab[token])
+          self.heads.append(head)
+          self.labels.append(dataset.relations_vocab[relation])
 
 def load_from_file(file_path: str, cache=True) -> DataSet:
   """

--- a/tests/input_pipeline/data_extraction_test.py
+++ b/tests/input_pipeline/data_extraction_test.py
@@ -12,7 +12,7 @@ class DataExtractionTest(absltest.TestCase):
 
   def test_load_from_file(self):
     file_path = "tests/test_data/example.conllu"
-    mock_data = load_from_file(file_path)
+    mock_data = load_from_file(file_path, cache=False)
     self.assertEqual(len(mock_data.dataset_entries), 1)
     dataset_entry = mock_data.dataset_entries[0]
     act_seq = generate_sequence_of_actions(dataset_entry.tokens,

--- a/tests/input_pipeline/data_extraction_test.py
+++ b/tests/input_pipeline/data_extraction_test.py
@@ -11,7 +11,7 @@ from the project root directory.
 class DataExtractionTest(absltest.TestCase):
 
   def test_load_from_file(self):
-    file_path = "/home/paul/PycharmProjects/transition-based/tests/test_data/example.conllu"
+    file_path = "tests/test_data/example.conllu"
     mock_data = load_from_file(file_path)
     self.assertEqual(len(mock_data.dataset_entries), 1)
     dataset_entry = mock_data.dataset_entries[0]


### PR DESCRIPTION
Fix the missing heads issue.

The problem was that for some tokenized words, eg ("don't" -> "do","not") the initial word is maintained as well, but it has no associated information, as the tokenized words have the necessary info. Therefore, such words can be skipped in the data extraction.